### PR TITLE
Added RedRyder BB Gun Ammo to Loot Table

### DIFF
--- a/SQF/dayz_code/Configs/CfgLoot/CfgLoot.hpp
+++ b/SQF/dayz_code/Configs/CfgLoot/CfgLoot.hpp
@@ -84,6 +84,7 @@ class CfgLoot {
 		,{"8Rnd_9x18_Makarov",0.08}
 		,{"15Rnd_W1866_Slug",0.02}
 		,{"WoodenArrow",0.04}
+		,{"350Rnd_BB_Magazine",0.05}
 		,{"HandRoadFlare",0.07}
 		,{"ItemPainkiller",0.02}
 		,{"HandChemGreen",0.01}
@@ -115,6 +116,7 @@ class CfgLoot {
 		,{"8Rnd_9x18_Makarov",0.09}
 		,{"15Rnd_W1866_Slug",0.02}
 		,{"WoodenArrow",0.04}
+		,{"350Rnd_BB_Magazine",0.05}
 		,{"HandRoadFlare",0.07}
 		,{"ItemPainkiller",0.02}
 		,{"HandChemGreen",0.01}
@@ -247,6 +249,7 @@ class CfgLoot {
 		,{"10x_303",0.1}
 		,{"ItemWaterbottleUnfilled",0.05}
 		,{"WoodenArrow",0.2}
+		,{"350Rnd_BB_Magazine",0.05}
 		,{"ItemHeatPack",0.02}
 		,{"FoodMRE",0.01}
 		,{"FoodNutmix",0.02}


### PR DESCRIPTION
Forgot to add the ammo.

Added ammo to "hunter", "generic" and "office". Chance of spawn is 0.05

Classname: "350Rnd_BB_Magazine"