### PR TITLE
Update UH1.hpp

### DIFF
--- a/SQF/dayz_code/Configs/CfgVehicles/AIR/UH1.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/AIR/UH1.hpp
@@ -31,10 +31,12 @@ class UH1Y_DZ: UH1_Base {
 	fuelCapacity = 1333;
 	class Turrets : Turrets {
 		class MainTurret : MainTurret {
-			magazines[] = {"2000Rnd_762x51_M134"};
+			weapons[] = {"M134"};
+    			magazines[] = {"2000Rnd_762x51_M134"};
 		};
 		class RightDoorGun : RightDoorGun {
-			magazines[] = {"2000Rnd_762x51_M134"};
+			weapons[] = {"M134"};
+    			magazines[] = {"2000Rnd_762x51_M134"};
 		};
 	};
 };
@@ -77,9 +79,11 @@ class UH1H_DZ: UH1H_base {
 	fuelCapacity = 1333;
 	class Turrets : Turrets {
 		class MainTurret : MainTurret {
+			weapons[] = {"M240"};
 			magazines[] = {"100Rnd_762x51_M240"};
 		};
 		class LeftDoorGun : LeftDoorGun {
+			weapons[] = {"M240"};
 			magazines[] = {"100Rnd_762x51_M240"};
 		};
 	};


### PR DESCRIPTION
Updated turrets to drop the actual weapons into them.

This should correct the DZE "Broken turret" errors.

21:17:49 UH1Y_DZE: ObsTurret - unknown animation source ObsTurret 21:17:49 UH1Y_DZE: ObsGun - unknown animation source ObsGun.

The animation sources might also need to be updated in the main cfgVehicles.hpp