### PR TITLE
Update Lada.hpp

### DIFF
--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/Lada.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/Lada.hpp
@@ -503,6 +503,7 @@ class Lada2_TK_CIV_EP1_DZE1: Lada2_TK_CIV_EP1 {
 // Armor 2
 class Lada1_DZE2: Lada1_DZE1 {
 	armor = 50; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -550,6 +551,7 @@ class Lada1_DZE2: Lada1_DZE1 {
 };
 class Lada2_DZE2: Lada2_DZE1 {
 	armor = 50; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -597,6 +599,7 @@ class Lada2_DZE2: Lada2_DZE1 {
 };
 class LadaLM_DZE2: LadaLM_DZE1 {
 	armor = 50; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -644,6 +647,7 @@ class LadaLM_DZE2: LadaLM_DZE1 {
 };
 class Lada1_TK_CIV_EP1_DZE2: Lada1_TK_CIV_EP1_DZE1 {
 	armor = 50; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -691,6 +695,7 @@ class Lada1_TK_CIV_EP1_DZE2: Lada1_TK_CIV_EP1_DZE1 {
 };
 class Lada2_TK_CIV_EP1_DZE2: Lada2_TK_CIV_EP1_DZE1 {
 	armor = 50; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -786,17 +791,17 @@ class Lada2_TK_CIV_EP1_DZE3: Lada2_TK_CIV_EP1_DZE2 {
 
 // Fuel 4
 class Lada1_DZE4: Lada1_DZE3 {
-	fuelCapacity = 210; // car 100
+	fuelCapacity = 150; // car 50
 };
 class Lada2_DZE4: Lada2_DZE3 {
-	fuelCapacity = 210; // car 100
+	fuelCapacity = 150; // car 50
 };
 class LadaLM_DZE4: LadaLM_DZE3 {
-	fuelCapacity = 210; // car 100
+	fuelCapacity = 150; // car 50
 };
 class Lada1_TK_CIV_EP1_DZE4: Lada1_TK_CIV_EP1_DZE3 {
-	fuelCapacity = 210; // car 100
+	fuelCapacity = 150; // car 50
 };
 class Lada2_TK_CIV_EP1_DZE4: Lada2_TK_CIV_EP1_DZE3 {
-	fuelCapacity = 210; // car 100
+	fuelCapacity = 150; // car 50
 };


### PR DESCRIPTION
Added "damageResistance = 0.02099;" to the DZE2 variants.  This should let the armor perform more like a humvee then before (humvee = 0.03099).  This pushes the value of the damage resistance to about 1.5X better.

Reduced fuelcapacity on all upgrade models, as the tank is set @ 50 and not 100.   Because of the lower amount, the tank upgrades shouldn't exceed 105L (to keep it at the correct ratio). However, 150 seems like a fair compromise, 1/2 way between the calculated 105L and the previous 210L.