### PR TITLE
Fix UAZ Cargo Upgrade & Balance Armor Upgrades

### DIFF
--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/Lada.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/Lada.hpp
@@ -502,7 +502,8 @@ class Lada2_TK_CIV_EP1_DZE1: Lada2_TK_CIV_EP1 {
 
 // Armor 2
 class Lada1_DZE2: Lada1_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -549,7 +550,8 @@ class Lada1_DZE2: Lada1_DZE1 {
 	};
 };
 class Lada2_DZE2: Lada2_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -596,7 +598,8 @@ class Lada2_DZE2: Lada2_DZE1 {
 	};
 };
 class LadaLM_DZE2: LadaLM_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -643,7 +646,8 @@ class LadaLM_DZE2: LadaLM_DZE1 {
 	};
 };
 class Lada1_TK_CIV_EP1_DZE2: Lada1_TK_CIV_EP1_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -690,7 +694,8 @@ class Lada1_TK_CIV_EP1_DZE2: Lada1_TK_CIV_EP1_DZE1 {
 	};
 };
 class Lada2_TK_CIV_EP1_DZE2: Lada2_TK_CIV_EP1_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/Offroad_DSHKM.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/Offroad_DSHKM.hpp
@@ -360,7 +360,8 @@ class Offroad_DSHKM_Gue_DZE1: Offroad_DSHKM_Gue_DZE
 // Armmor 2
 class Offroad_DSHKM_Gue_DZE2: Offroad_DSHKM_Gue_DZE1
 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints
 	{
 		class HitLFWheel: HitLFWheel

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/Pickup_PK.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/Pickup_PK.hpp
@@ -146,7 +146,8 @@ class Pickup_PK_INS_DZE1: Pickup_PK_INS_DZE {
 
 // Armor 2
 class Pickup_PK_GUE_DZE2: Pickup_PK_GUE_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -193,7 +194,8 @@ class Pickup_PK_GUE_DZE2: Pickup_PK_GUE_DZE1 {
 	};
 };
 class Pickup_PK_TK_GUE_EP1_DZE2: Pickup_PK_TK_GUE_EP1_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -240,7 +242,8 @@ class Pickup_PK_TK_GUE_EP1_DZE2: Pickup_PK_TK_GUE_EP1_DZE1 {
 	};
 };
 class Pickup_PK_INS_DZE2: Pickup_PK_INS_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/SUV.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/SUV.hpp
@@ -420,7 +420,8 @@ class SUV_Silver_DZE1: SUV_Silver {
 
 // Armor 2
 class SUV_TK_CIV_EP1_DZE2: SUV_TK_CIV_EP1_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -467,7 +468,8 @@ class SUV_TK_CIV_EP1_DZE2: SUV_TK_CIV_EP1_DZE1 {
 	};
 };
 class SUV_Camo_DZE2: SUV_Camo_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -514,7 +516,8 @@ class SUV_Camo_DZE2: SUV_Camo_DZE1 {
 	};
 };
 class SUV_Blue_DZE2: SUV_Blue_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -561,7 +564,8 @@ class SUV_Blue_DZE2: SUV_Blue_DZE1 {
 	};
 };
 class SUV_Green_DZE2: SUV_Green_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -608,7 +612,8 @@ class SUV_Green_DZE2: SUV_Green_DZE1 {
 	};
 };
 class SUV_Yellow_DZE2: SUV_Yellow_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -655,7 +660,8 @@ class SUV_Yellow_DZE2: SUV_Yellow_DZE1 {
 	};
 };
 class SUV_Red_DZE2: SUV_Red_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -702,7 +708,8 @@ class SUV_Red_DZE2: SUV_Red_DZE1 {
 	};
 };
 class SUV_White_DZE2: SUV_White_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -749,7 +756,8 @@ class SUV_White_DZE2: SUV_White_DZE1 {
 	};
 };
 class SUV_Pink_DZE2: SUV_Pink_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -796,7 +804,8 @@ class SUV_Pink_DZE2: SUV_Pink_DZE1 {
 	};
 };
 class SUV_Charcoal_DZE2: SUV_Charcoal_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -843,7 +852,8 @@ class SUV_Charcoal_DZE2: SUV_Charcoal_DZE1 {
 	};
 };
 class SUV_Orange_DZE2: SUV_Orange_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -890,7 +900,8 @@ class SUV_Orange_DZE2: SUV_Orange_DZE1 {
 	};
 };
 class SUV_Silver_DZE2: SUV_Silver_DZE1 {
-	armor = 50; // car 20
+	armor = 60; // car 20, SUV 25
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/Skoda.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/Skoda.hpp
@@ -304,7 +304,8 @@ class SkodaGreen_DZE1: SkodaGreen {
 
 // Armor 2
 class Skoda_DZE2: Skoda_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -351,7 +352,8 @@ class Skoda_DZE2: Skoda_DZE1 {
 	};
 };
 class SkodaBlue_DZE2: SkodaBlue_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -398,7 +400,8 @@ class SkodaBlue_DZE2: SkodaBlue_DZE1 {
 	};
 };
 class SkodaRed_DZE2: SkodaRed_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -445,7 +448,8 @@ class SkodaRed_DZE2: SkodaRed_DZE1 {
 	};
 };
 class SkodaGreen_DZE2: SkodaGreen_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/UAZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/UAZ.hpp
@@ -511,7 +511,7 @@ class UAZ_Unarmed_TK_CIV_EP1_DZE2: UAZ_Unarmed_TK_CIV_EP1_DZE1 {
 class UAZ_CDF_DZE3: UAZ_CDF_DZE2 {
 	transportMaxWeapons = 20;  // car 10
 	transportMaxMagazines = 100; // car 50
-    transportmaxbackpacks = 4; // car 2
+    transportmaxbackpacks = 9; // car 2, UAZ 7
 
 	class Upgrades {
 		ItemTNK[] = {"UAZ_CDF_DZE4",{},{{"ItemTNK",1},{"PartFueltank",2}}};
@@ -520,7 +520,7 @@ class UAZ_CDF_DZE3: UAZ_CDF_DZE2 {
 class UAZ_INS_DZE3: UAZ_INS_DZE2 {
 	transportMaxWeapons = 20;  // car 10
 	transportMaxMagazines = 100; // car 50
-    transportmaxbackpacks = 4; // car 2
+    transportmaxbackpacks = 9; // car 2, UAZ 7
 
 	class Upgrades {
 		ItemTNK[] = {"UAZ_INS_DZE4",{},{{"ItemTNK",1},{"PartFueltank",2}}};
@@ -529,7 +529,7 @@ class UAZ_INS_DZE3: UAZ_INS_DZE2 {
 class UAZ_RU_DZE3: UAZ_RU_DZE2 {
 	transportMaxWeapons = 20;  // car 10
 	transportMaxMagazines = 100; // car 50
-    transportmaxbackpacks = 4; // car 2
+    transportmaxbackpacks = 9; // car 2, UAZ 7
 
 	class Upgrades {
 		ItemTNK[] = {"UAZ_RU_DZE4",{},{{"ItemTNK",1},{"PartFueltank",2}}};
@@ -538,7 +538,7 @@ class UAZ_RU_DZE3: UAZ_RU_DZE2 {
 class UAZ_Unarmed_TK_EP1_DZE3: UAZ_Unarmed_TK_EP1_DZE2 {
 	transportMaxWeapons = 20;  // car 10
 	transportMaxMagazines = 100; // car 50
-    transportmaxbackpacks = 4; // car 2
+    transportmaxbackpacks = 9; // car 2, UAZ 7
 
 	class Upgrades {
 		ItemTNK[] = {"UAZ_Unarmed_TK_EP1_DZE4",{},{{"ItemTNK",1},{"PartFueltank",2}}};
@@ -547,7 +547,7 @@ class UAZ_Unarmed_TK_EP1_DZE3: UAZ_Unarmed_TK_EP1_DZE2 {
 class UAZ_Unarmed_UN_EP1_DZE3: UAZ_Unarmed_UN_EP1_DZE2 {
 	transportMaxWeapons = 20;  // car 10
 	transportMaxMagazines = 100; // car 50
-    transportmaxbackpacks = 4; // car 2
+    transportmaxbackpacks = 9; // car 2, UAZ 7
 
 	class Upgrades {
 		ItemTNK[] = {"UAZ_Unarmed_UN_EP1_DZE4",{},{{"ItemTNK",1},{"PartFueltank",2}}};
@@ -556,7 +556,7 @@ class UAZ_Unarmed_UN_EP1_DZE3: UAZ_Unarmed_UN_EP1_DZE2 {
 class UAZ_Unarmed_TK_CIV_EP1_DZE3: UAZ_Unarmed_TK_CIV_EP1_DZE2 {
 	transportMaxWeapons = 20;  // car 10
 	transportMaxMagazines = 100; // car 50
-    transportmaxbackpacks = 4; // car 2
+    transportmaxbackpacks = 9; // car 2, UAZ 7
 
 	class Upgrades {
 		ItemTNK[] = {"UAZ_Unarmed_TK_CIV_EP1_DZE4",{},{{"ItemTNK",1},{"PartFueltank",2}}};

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/UAZ.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/UAZ.hpp
@@ -219,7 +219,7 @@ class UAZ_Unarmed_TK_CIV_EP1_DZE1: UAZ_Unarmed_TK_CIV_EP1 {
 
 // Armor 2
 class UAZ_CDF_DZE2: UAZ_CDF_DZE1 {
-	armor = 100; // UAZ 40
+	armor = 75; // UAZ 40
 	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
@@ -267,7 +267,7 @@ class UAZ_CDF_DZE2: UAZ_CDF_DZE1 {
 	};
 };
 class UAZ_INS_DZE2: UAZ_INS_DZE1 {
-	armor = 100; // UAZ 40
+	armor = 75; // UAZ 40
 	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
@@ -315,7 +315,7 @@ class UAZ_INS_DZE2: UAZ_INS_DZE1 {
 	};
 };
 class UAZ_RU_DZE2: UAZ_RU_DZE1 {
-	armor = 100; // UAZ 40
+	armor = 75; // UAZ 40
 	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
@@ -363,7 +363,7 @@ class UAZ_RU_DZE2: UAZ_RU_DZE1 {
 	};
 };
 class UAZ_Unarmed_TK_EP1_DZE2: UAZ_Unarmed_TK_EP1_DZE1 {
-	armor = 100; // UAZ 40
+	armor = 75; // UAZ 40
 	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
@@ -411,7 +411,7 @@ class UAZ_Unarmed_TK_EP1_DZE2: UAZ_Unarmed_TK_EP1_DZE1 {
 	};
 };
 class UAZ_Unarmed_UN_EP1_DZE2: UAZ_Unarmed_UN_EP1_DZE1 {
-	armor = 100; // UAZ 40
+	armor = 75; // UAZ 40
 	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
@@ -459,7 +459,7 @@ class UAZ_Unarmed_UN_EP1_DZE2: UAZ_Unarmed_UN_EP1_DZE1 {
 	};
 };
 class UAZ_Unarmed_TK_CIV_EP1_DZE2: UAZ_Unarmed_TK_CIV_EP1_DZE1 {
-	armor = 100; // UAZ 40
+	armor = 75; // UAZ 40
 	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/VWGolf.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/VWGolf.hpp
@@ -504,7 +504,8 @@ class VWGolf_DZE1: VWGolf {
 
 // Armor 2
 class VWGolf_DZE2: VWGolf_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/Volha.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/Volha.hpp
@@ -280,7 +280,7 @@ class Volha_2_TK_CIV_EP1_DZE1: Volha_2_TK_CIV_EP1 {
 
 // Armor 2
 class VolhaLimo_TK_CIV_EP1_DZE2: VolhaLimo_TK_CIV_EP1_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
 	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
@@ -328,7 +328,7 @@ class VolhaLimo_TK_CIV_EP1_DZE2: VolhaLimo_TK_CIV_EP1_DZE1 {
 	};
 };
 class Volha_1_TK_CIV_EP1_DZE2: Volha_1_TK_CIV_EP1_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
 	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
@@ -376,7 +376,7 @@ class Volha_1_TK_CIV_EP1_DZE2: Volha_1_TK_CIV_EP1_DZE1 {
 	};
 };
 class Volha_2_TK_CIV_EP1_DZE2: Volha_2_TK_CIV_EP1_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
 	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/datsun.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/datsun.hpp
@@ -96,7 +96,8 @@ class datsun1_civil_3_open_DZE1: datsun1_civil_3_open_DZE {
 
 // Armor 2
 class datsun1_civil_1_open_DZE2: datsun1_civil_1_open_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -144,7 +145,8 @@ class datsun1_civil_1_open_DZE2: datsun1_civil_1_open_DZE1 {
 	};
 };
 class datsun1_civil_2_covered_DZE2: datsun1_civil_2_covered_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -192,7 +194,8 @@ class datsun1_civil_2_covered_DZE2: datsun1_civil_2_covered_DZE1 {
 	};
 };
 class datsun1_civil_3_open_DZE2: datsun1_civil_3_open_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;

--- a/SQF/dayz_code/Configs/CfgVehicles/LAND/hilux.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/LAND/hilux.hpp
@@ -96,7 +96,8 @@ class hilux1_civil_3_open_DZE1: hilux1_civil_3_open_DZE {
 
 // Armor 2
 class hilux1_civil_1_open_DZE2: hilux1_civil_1_open_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -144,7 +145,8 @@ class hilux1_civil_1_open_DZE2: hilux1_civil_1_open_DZE1 {
 	};
 };
 class hilux1_civil_2_covered_DZE2: hilux1_civil_2_covered_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;
@@ -192,7 +194,8 @@ class hilux1_civil_2_covered_DZE2: hilux1_civil_2_covered_DZE1 {
 	};
 };
 class hilux1_civil_3_open_DZE2: hilux1_civil_3_open_DZE1 {
-	armor = 50; // car 20
+	armor = 55; // car 20
+	damageResistance = 0.02099;
 	class HitPoints: HitPoints {
 		class HitLFWheel: HitLFWheel {
 			armor = 0.3;

--- a/SQF/dayz_epoch_b/CfgServerTrader/Category/FriendlyAssaultRifle.hpp
+++ b/SQF/dayz_epoch_b/CfgServerTrader/Category/FriendlyAssaultRifle.hpp
@@ -218,7 +218,7 @@ class Category_615 {
 	};
 	class BAF_L85A2_RIS_Holo {
 		type = "trade_weapons";
-		buy[] = {9,"ItemGoldBar10oz"};
+		buy[] = {9,"ItemGoldBar"};
 		sell[] = {6,"ItemGoldBar"};
 	};
 };

--- a/SQF/dayz_epoch_b/CfgServerTrader/Category/FriendlyAssaultRifle.hpp
+++ b/SQF/dayz_epoch_b/CfgServerTrader/Category/FriendlyAssaultRifle.hpp
@@ -106,7 +106,7 @@ class Category_485 {
 	};
 	class BAF_L85A2_RIS_Holo {
 		type = "trade_weapons";
-		buy[] = {9,"ItemGoldBar10oz"};
+		buy[] = {9,"ItemGoldBar"};
 		sell[] = {6,"ItemGoldBar"};
 	};
 };

--- a/SQF/dayz_epoch_b/CfgServerTrader/Category/NeutralAssaultRifle.hpp
+++ b/SQF/dayz_epoch_b/CfgServerTrader/Category/NeutralAssaultRifle.hpp
@@ -106,7 +106,7 @@ class Category_602 {
 	};
 	class BAF_L85A2_RIS_Holo {
 		type = "trade_weapons";
-		buy[] = {9,"ItemGoldBar10oz"};
+		buy[] = {9,"ItemGoldBar"};
 		sell[] = {6,"ItemGoldBar"};
 	};
 };
@@ -218,7 +218,7 @@ class Category_637 {
 	};
 	class BAF_L85A2_RIS_Holo {
 		type = "trade_weapons";
-		buy[] = {9,"ItemGoldBar10oz"};
+		buy[] = {9,"ItemGoldBar"};
 		sell[] = {6,"ItemGoldBar"};
 	};
 };


### PR DESCRIPTION
Corrected UAZ pack upgrade to be consistent with other vehicle upgrades. Balanced armor upgrades in reference to other vehicles like the Vodnick and Armored SUV, made them consistent, and slightly improved them overall to make upgrades a little more worthwhile.

After reviewing all vehicles and upgrades I think a flat armor upgrade of +35 and a consistent damage resistance of 0.02099 across all upgrades would be fairly balanced resulting in:

Vodnick 85 armor, damageResistance = 0.032 (no change)
Armored SUV 80 armor, damageResistance = 0.03099 (no change)
UAZ Upgrade 40+35 = 75 armor, damageResistance = 0.02099 (-25 armor)
SUV Upgrade 25+35 = 60 armor, damageResistance = 0.02099 (+10 armor + .014)
Car Upgrade 20+35 = 55 armor, damageResistance = 0.02099 (+5 armor + varies - see below)

Currently inconsistent damageResistance after armor upgrade:
UAZ 0.02099 (max)
Lada 0.01511 (base, comparatively high)
DSHKM none
Pickup PK none
SUV 0.00635 (base, comparatively low)
Skoda 0.01821 (base, comparatively high)
VWGolf 0.01511 (base, comparatively high)
Volha 0.02099 (max)
Datsun none
Hilux none