### PR TITLE
Delete old group after changing clothes

### DIFF
--- a/SQF/dayz_code/compile/player_switchModel.sqf
+++ b/SQF/dayz_code/compile/player_switchModel.sqf
@@ -1,4 +1,4 @@
-private ["_weapons","_backpackWpn","_backpackMag","_currentWpn","_isWeapon","_backpackWpnTypes","_backpackWpnQtys","_countr","_class","_position","_dir","_currentAnim","_tagSetting","_playerUID","_countMags","_magazines","_primweapon","_secweapon","_newBackpackType","_muzzles","_oldUnit","_group","_newUnit","_playerObjName","_wpnType","_ismelee"];
+private ["_weapons","_backpackWpn","_backpackMag","_currentWpn","_isWeapon","_backpackWpnTypes","_backpackWpnQtys","_countr","_class","_position","_dir","_currentAnim","_tagSetting","_playerUID","_countMags","_magazines","_primweapon","_secweapon","_newBackpackType","_muzzles","_oldUnit","_group","_newUnit","_playerObjName","_wpnType","_ismelee","_oldGroup"];
 if (gear_done) then {disableUserInput true;};
 _class 			= _this;
 _position 		= getPosATL player;
@@ -43,6 +43,7 @@ player setPosATL dayz_spawnPos;
 
 //BackUp Player Object
 _oldUnit = player;
+_oldGroup = group player;
 
 /**********************************/
 //DONT USE player AFTER THIS POINT//
@@ -110,6 +111,7 @@ _switchUnit = {
 	removeAllWeapons _oldUnit;
 	{_oldUnit removeMagazine _x;} count  magazines _oldUnit;
 	deleteVehicle _oldUnit;
+	if (count units _oldGroup < 1) then {deleteGroup _oldGroup;};
 	if(_currentWpn != "") then {_newUnit selectWeapon _currentWpn;};
 };
 //Add && Fill BackPack


### PR DESCRIPTION
The deleteGroup command requires the group to be local to the machine executing it:
https://community.bistudio.com/wiki/deleteGroup

When a player changes clothes a new group is created. The player is switched into a new unit in the new group, and then his old group is left empty. Because the old group is local to the player, it will not be deleted by server_cleanupGroups until he disconnects and it is transferred to the server. 

We should delete the old group immediately rather than wait for the player to disconnect. This will prevent the excessive accumulation of empty groups when players change clothes a lot. It will help with the seagull spawn issue which happens when there are more than 144 groups on side WEST:
https://community.bistudio.com/wiki/createGroup

I have been running this fix on busy live servers for months now without issue. 