### PR TITLE
Add the _ to the Land and escape the character

### DIFF
--- a/Server Files/SQL/add_recommended_mysql_events.sql
+++ b/Server Files/SQL/add_recommended_mysql_events.sql
@@ -46,7 +46,7 @@ BEGIN
 		AND `Object_DATA`.`CharacterID` <= 12500
 		AND `Object_DATA`.`Classname` NOT LIKE 'Tent%'
 		AND `Object_DATA`.`Classname` NOT LIKE '%Locked'
-		AND `Object_DATA`.`Classname` NOT LIKE 'Land%'
+		AND `Object_DATA`.`Classname` NOT LIKE 'Land\_%' -- added escape character so LandRover vehicles are not ignored
 		AND `Object_DATA`.`Classname` NOT LIKE 'Cinder%'
 		AND `Object_DATA`.`Classname` NOT LIKE 'Wood%'
 		AND `Object_DATA`.`Classname` NOT LIKE 'Metal%'
@@ -118,7 +118,7 @@ CREATE EVENT `UnlockNonKeyVehicles` ON SCHEDULE EVERY 1 DAY DO UPDATE
 			AND `Object_DATA`.`CharacterID` <= 12500
 			AND `Object_DATA`.`Classname` NOT LIKE 'Tent%'
 			AND `Object_DATA`.`Classname` NOT LIKE '%Locked'
-			AND `Object_DATA`.`Classname` NOT LIKE 'Land%'
+			AND `Object_DATA`.`Classname` NOT LIKE 'Land\_%' -- added escape character so LandRover vehicles are not ignored
 			AND `Object_DATA`.`Classname` NOT LIKE 'Cinder%'
 			AND `Object_DATA`.`Classname` NOT LIKE 'Wood%'
 			AND `Object_DATA`.`Classname` NOT LIKE 'Metal%'


### PR DESCRIPTION
LandRover vehicles are being ignored with this script.  If you escape the '_' (underscore) with '\' it will only look for the '_' (underscore) character used with all build able land objects.  Currently LandRover vehicles will not be unlocked or deleted, as they are ignored with the current 'Land%' match.