### PR TITLE
Fix TraderItemList variable should be initialized as array

### DIFF
--- a/CHANGE LOG 1.0.5.2.txt
+++ b/CHANGE LOG 1.0.5.2.txt
@@ -27,6 +27,7 @@
 [FIXED] Dynamic_vehicle spawning non-upgradable classes of hilux1 & datsun1.  @Uro1
 [FIXED] Eating while inside a vehicle did not drop empty can  @deadeye2
 [FIXED] Zombie loot error when using loot tables in mission file  @deadeye2
+[FIXED] TraderItemList error due to being initialized as number when it should be array @ebaydayz
 
 [UPDATED] .hpp files updated in dayz_epoch_b CfgLootPos > CfgBuildingPos. @Uro1
 [UPDATED] .bat files updated in Config-Examples @Raziel23x

--- a/SQF/dayz_code/actions/show_dialog.sqf
+++ b/SQF/dayz_code/actions/show_dialog.sqf
@@ -11,7 +11,7 @@ lbClear TraderDialogCatList;
 lbClear TraderDialogItemList;
 
 TraderCurrentCatIndex = -1;
-TraderItemList = -1;
+TraderItemList = [];
 
 TraderCatList = [];
 {

--- a/SQF/dayz_code/compile/player_traderMenuConfig.sqf
+++ b/SQF/dayz_code/compile/player_traderMenuConfig.sqf
@@ -9,11 +9,11 @@ TraderDialogCurrency = 12006;
 
 TraderCurrentCatIndex = -1;
 TraderCatList = -1;
-TraderItemList = -1;
+TraderItemList = [];
 
 TraderDialogLoadItemList = {
 	private ["_index","_trader_id","_activatingPlayer","_distance","_objclass","_item_list"];
-	TraderItemList = -1;
+	TraderItemList = [];
 	_index = _this select 0;
 
 	if (_index < 0) exitWith {};
@@ -210,7 +210,7 @@ TraderDialogBuy = {
 	_item = TraderItemList select _index;
 	_data = [_item select 0, _item select 3, 1, _item select 2, "buy", _item select 4, _item select 1, _item select 8];
 	[0, player, '', _data] execVM (_item select 9);
-	TraderItemList = -1;
+	TraderItemList = [];
 };
 
 TraderDialogSell = {
@@ -222,5 +222,5 @@ TraderDialogSell = {
 	_item = TraderItemList select _index;
 	_data = [_item select 6, _item select 0, _item select 5, 1, "sell", _item select 1, _item select 7, _item select 8];
 	[0, player, '', _data] execVM (_item select 9);
-	TraderItemList = -1;
+	TraderItemList = [];
 };

--- a/SQF/dayz_code/compile/player_traderMenuHive.sqf
+++ b/SQF/dayz_code/compile/player_traderMenuHive.sqf
@@ -9,11 +9,11 @@ TraderDialogCurrency = 12006;
 
 TraderCurrentCatIndex = -1;
 TraderCatList = -1;
-TraderItemList = -1;
+TraderItemList = [];
 
 TraderDialogLoadItemList = {
 	private ["_index","_trader_id","_activatingPlayer","_distance","_objclass","_item_list"];
-	TraderItemList = -1;
+	TraderItemList = [];
 	_index = _this select 0;
 
 	if (_index < 0 || TraderCurrentCatIndex == _index) exitWith {};
@@ -198,7 +198,7 @@ TraderDialogBuy = {
 	_item = TraderItemList select _index;
 	_data = [_item select 0, _item select 3, 1, _item select 2, "buy", _item select 4, _item select 1, _item select 8];
 	[0, player, '', _data] execVM (_item select 9);
-	TraderItemList = -1;
+	TraderItemList = [];
 };
 
 TraderDialogSell = {
@@ -210,5 +210,5 @@ TraderDialogSell = {
 	_item = TraderItemList select _index;
 	_data = [_item select 6, _item select 0, _item select 5, 1, "sell", _item select 1, _item select 7, _item select 8];
 	[0, player, '', _data] execVM (_item select 9);
-	TraderItemList = -1;
+	TraderItemList = [];
 };


### PR DESCRIPTION
TraderItemList variable should be initialized as an array, not a number. Fixes this error:
```
Error in expression < 0;
if (_index < 0) exitWith {};
while {count TraderItemList < 1} do { sleep 1; >
  Error position: <count TraderItemList < 1} do { sleep 1; >
  Error count: Type Number, expected Array,Config entry
File z\addons\dayz_code\compile\player_traderMenuHive.sqf, line 174
```
See: https://github.com/vbawol/DayZ-Epoch/issues/1616

I've tested these changes with no issues.