### PR TITLE
Fix trader menu expected array error

### DIFF
--- a/SQF/dayz_code/actions/show_dialog.sqf
+++ b/SQF/dayz_code/actions/show_dialog.sqf
@@ -11,7 +11,7 @@ lbClear TraderDialogCatList;
 lbClear TraderDialogItemList;
 
 TraderCurrentCatIndex = -1;
-TraderItemList = -1;
+TraderItemList = [];
 
 TraderCatList = [];
 {
@@ -21,4 +21,4 @@ TraderCatList = [];
 } count _trader_data;
 waitUntil { !dialog };
 TraderCurrentCatIndex = -1;
-TraderCatList = -1;
+TraderCatList = [];


### PR DESCRIPTION
TraderItemList and TraderCatList should be initialized as arrays, not numbers. Fixes this error:
```
Error in expression < 0;
if (_index < 0) exitWith {};
while {count TraderItemList < 1} do { sleep 1; >
  Error position: <count TraderItemList < 1} do { sleep 1; >
  Error count: Type Number, expected Array,Config entry
File z\addons\dayz_code\compile\player_traderMenuHive.sqf, line 174
```
See: https://github.com/vbawol/DayZ-Epoch/issues/1616

Tested buying and selling to all the stary and base traders as well as the boat dealer with these changes. No more error or problems.