### PR TITLE
Fix rare occasion of gear not updating

### DIFF
--- a/SQF/dayz_code/compile/player_gearSync.sqf
+++ b/SQF/dayz_code/compile/player_gearSync.sqf
@@ -1,5 +1,5 @@
 private ["_objects"];
-_objects = nearestObjects [getPosATL player, dayz_updateObjects, 10];
+_objects = nearestObjects [player, dayz_updateObjects, 10];
 {
 	//["PVDZE_veh_Update",[_x,"gear"]] call callRpcProcedure;
 	PVDZE_veh_Update = [_x,"gear"];


### PR DESCRIPTION
getPosATL doesn't work for all scenarios, it's better to just use player and let the game work out if you're above water or not etc...