### PR TITLE
Fix for "Undefined base class" with FN FAL

### DIFF
--- a/SQF/dayz_code/Configs/CfgWeapons/Weapon/Rifle/FN_FAL_ANPVS4_DZE.hpp
+++ b/SQF/dayz_code/Configs/CfgWeapons/Weapon/Rifle/FN_FAL_ANPVS4_DZE.hpp
@@ -1,3 +1,4 @@
+class FN_FAL_ANPVS4;
 class FN_FAL_ANPVS4_DZE:FN_FAL_ANPVS4 {
   visionMode[] = {"Normal", "NVG"};
 };


### PR DESCRIPTION
This line fixes the "Undefined base class" error for the FN_FAL_ANPVS4_DZE you get when trying to compile dayz_code.