### PR TITLE
Keep hiddenSelections for armed Mi17

### DIFF
--- a/SQF/dayz_code/Configs/CfgVehicles/AIR/Mi17.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/AIR/Mi17.hpp
@@ -17,7 +17,6 @@ class Mi17_DZ: Mi17_base	 {
 	side = 2;
 	crew = "";
 	typicalCargo[] = {};
-	hiddenSelections[] = {};
 	class TransportMagazines{};
 	class TransportWeapons{};
 	commanderCanSee = 2+16+32;


### PR DESCRIPTION
hiddenSelections = {}; removes the option to use custom textures on the armed version. The civilian one has these hiddenSelections. Removing this line allows to use setObjectTexture.