### PR TITLE
Remove hiddenSelections restrictions

### DIFF
--- a/SQF/dayz_code/Configs/CfgVehicles/AIR/AN2.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/AIR/AN2.hpp
@@ -8,7 +8,6 @@ class AN2_DZ: An2_Base_EP1
 	side = 2;
 	crew = "";
 	typicalCargo[] = {};
-	hiddenSelections[] = {};
 	class TransportMagazines{};
 	class TransportWeapons{};
 	weapons[] = {};

--- a/SQF/dayz_code/Configs/CfgVehicles/AIR/Mi17.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/AIR/Mi17.hpp
@@ -17,7 +17,6 @@ class Mi17_DZ: Mi17_base	 {
 	side = 2;
 	crew = "";
 	typicalCargo[] = {};
-	hiddenSelections[] = {};
 	class TransportMagazines{};
 	class TransportWeapons{};
 	commanderCanSee = 2+16+32;

--- a/SQF/dayz_code/Configs/CfgVehicles/AIR/UH1.hpp
+++ b/SQF/dayz_code/Configs/CfgVehicles/AIR/UH1.hpp
@@ -17,7 +17,6 @@ class UH1Y_DZ: UH1_Base {
 	side = 2;
 	crew = "";
 	typicalCargo[] = {};
-	hiddenSelections[] = {};
 	class TransportMagazines{};
 	class TransportWeapons{};
 	commanderCanSee = 2+16+32;
@@ -65,7 +64,6 @@ class UH1H_DZ: UH1H_base {
 	side = 2;
 	crew = "";
 	typicalCargo[] = {};
-	hiddenSelections[] = {};
 	class TransportMagazines{};
 	class TransportWeapons{};
 	commanderCanSee = 2+16+32;


### PR DESCRIPTION
hiddenSelections = {}; removes the option to use custom textures on some aircrafts. Removing these lines allows to use setObjectTexture.