### PR TITLE
Remove useless setting

### DIFF
--- a/Server Files/Config-Examples/instance_11_Chernarus/config.cfg
+++ b/Server Files/Config-Examples/instance_11_Chernarus/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_12_duala/config.cfg
+++ b/Server Files/Config-Examples/instance_12_duala/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_13_tavi/config.cfg
+++ b/Server Files/Config-Examples/instance_13_tavi/config.cfg
@@ -29,8 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
-
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_15_namalsk/config.cfg
+++ b/Server Files/Config-Examples/instance_15_namalsk/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_16_panthera/config.cfg
+++ b/Server Files/Config-Examples/instance_16_panthera/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_18_sahrani/config.cfg
+++ b/Server Files/Config-Examples/instance_18_sahrani/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_19_poda/config.cfg
+++ b/Server Files/Config-Examples/instance_19_poda/config.cfg
@@ -29,8 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
-
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_1_takistan/config.cfg
+++ b/Server Files/Config-Examples/instance_1_takistan/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_20_fapovo/config.cfg
+++ b/Server Files/Config-Examples/instance_20_fapovo/config.cfg
@@ -29,8 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
-
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_21_caribou/config.cfg
+++ b/Server Files/Config-Examples/instance_21_caribou/config.cfg
@@ -29,8 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
-
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_22_SMDsahrani/config.cfg
+++ b/Server Files/Config-Examples/instance_22_SMDsahrani/config.cfg
@@ -29,8 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
-
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_24_Napf/config.cfg
+++ b/Server Files/Config-Examples/instance_24_Napf/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_25_sauerland/config.cfg
+++ b/Server Files/Config-Examples/instance_25_sauerland/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_2_utes/config.cfg
+++ b/Server Files/Config-Examples/instance_2_utes/config.cfg
@@ -29,8 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
-
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_3_shapur_baf/config.cfg
+++ b/Server Files/Config-Examples/instance_3_shapur_baf/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_4_zargabad/config.cfg
+++ b/Server Files/Config-Examples/instance_4_zargabad/config.cfg
@@ -29,8 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
-
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_6_Dingor/config.cfg
+++ b/Server Files/Config-Examples/instance_6_Dingor/config.cfg
@@ -29,8 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
-
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_7_Lingor/config.cfg
+++ b/Server Files/Config-Examples/instance_7_Lingor/config.cfg
@@ -29,7 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
 
 class Missions
 {

--- a/Server Files/Config-Examples/instance_8_ProvingGrounds_PMC/config.cfg
+++ b/Server Files/Config-Examples/instance_8_ProvingGrounds_PMC/config.cfg
@@ -29,8 +29,6 @@ onDifferentData = "";
 
 regularCheck = "";
 requiredBuild = 125548;
-requiredSecureId = 2;
-
 
 class Missions
 {


### PR DESCRIPTION
requiredSecureId is deprecated and pretty much useless since the OA STEAM switch.

[10:10:19 | Edited 10:10:49] David Foltyn: secureID was deprecated and replaced with STEAMid, so imho that setting is now void