### PR TITLE
Correct output for deconstruction round bagfence

### DIFF
--- a/SQF/dayz_code/Configs/cfgVehicles.hpp
+++ b/SQF/dayz_code/Configs/cfgVehicles.hpp
@@ -840,7 +840,7 @@ class CfgVehicles {
 		displayName = "Bag fence (Round)";
 		vehicleClass = "Fortifications";
 		constructioncount = 3;
-		removeoutput[] = {{"ItemSandbag",1}};
+		removeoutput[] = {{"BagFenceRound_DZ_kit",1}};
 		nounderground = 0;
 	};
 


### PR DESCRIPTION
In 1.0.5.1 you get an ItemSandbag when removing a round sandbag