### PR TITLE
[FIX] Inventory wiping

### DIFF
--- a/SQF/dayz_code/system/player_spawn_2.sqf
+++ b/SQF/dayz_code/system/player_spawn_2.sqf
@@ -206,11 +206,10 @@ while {true} do {
 	//Save Checker
 	if (dayz_unsaved) then {
 		if ((time - dayz_lastSave) > DZE_SaveTime) then {
-			PVDZE_plr_Save = [player,dayz_Magazines,false,false];
+			PVDZE_plr_Save = [player,magazines player,false,false];
 			publicVariableServer "PVDZE_plr_Save";
 			dayz_unsaved = false;
 			dayz_lastSave = time;
-			dayz_Magazines = [];
 		};
 	};
 

--- a/SQF/dayz_code/system/player_spawn_2.sqf
+++ b/SQF/dayz_code/system/player_spawn_2.sqf
@@ -206,7 +206,7 @@ while {true} do {
 	//Save Checker
 	if (dayz_unsaved) then {
 		if ((time - dayz_lastSave) > DZE_SaveTime) then {
-			_dayzMags = if (count dayz_Magazines > 0) then {dayz_Magazines} else {magazines player};
+			_dayzMags = if (!isNil "dayz_Magazines" && {typeName dayz_Magazines} == "ARRAY" && {count dayz_Magazines > 0}) then {dayz_Magazines} else {magazines player};
 			PVDZE_plr_Save = [player,_dayzMags,false,false];
 			publicVariableServer "PVDZE_plr_Save";
 			dayz_unsaved = false;

--- a/SQF/dayz_code/system/player_spawn_2.sqf
+++ b/SQF/dayz_code/system/player_spawn_2.sqf
@@ -206,7 +206,7 @@ while {true} do {
 	//Save Checker
 	if (dayz_unsaved) then {
 		if ((time - dayz_lastSave) > DZE_SaveTime) then {
-			_dayzMags = if (!isNil "dayz_Magazines" && {typeName dayz_Magazines} == "ARRAY" && {count dayz_Magazines > 0}) then {dayz_Magazines} else {magazines player};
+			_dayzMags = if (!isNil "dayz_Magazines" && {typeName dayz_Magazines == "ARRAY"} && {count dayz_Magazines > 0}) then {dayz_Magazines} else {magazines player};
 			PVDZE_plr_Save = [player,_dayzMags,false,false];
 			publicVariableServer "PVDZE_plr_Save";
 			dayz_unsaved = false;

--- a/SQF/dayz_code/system/player_spawn_2.sqf
+++ b/SQF/dayz_code/system/player_spawn_2.sqf
@@ -1,4 +1,4 @@
-private ["_refObj","_size","_vel","_speed","_hunger","_thirst","_result","_factor","_distance","_lastTemp","_rnd","_listTalk","_id","_messTimer","_combatdisplay","_combatcontrol","_timeleft","_inVehicle","_lastUpdate","_foodVal","_thirstVal","_lowBlood","_startcombattimer","_combattimeout","_isPZombie","_outsideMap","_radsound","_bloodloss","_radTimer","_currentBlood","_wpnType"];
+private ["_refObj","_size","_vel","_speed","_hunger","_thirst","_result","_factor","_distance","_lastTemp","_rnd","_listTalk","_id","_messTimer","_combatdisplay","_combatcontrol","_timeleft","_inVehicle","_lastUpdate","_foodVal","_thirstVal","_lowBlood","_startcombattimer","_combattimeout","_isPZombie","_outsideMap","_radsound","_bloodloss","_radTimer","_currentBlood","_wpnType","_dayzMags"];
 disableSerialization;
 
 _messTimer = 0;
@@ -206,10 +206,12 @@ while {true} do {
 	//Save Checker
 	if (dayz_unsaved) then {
 		if ((time - dayz_lastSave) > DZE_SaveTime) then {
-			PVDZE_plr_Save = [player,magazines player,false,false];
+			_dayzMags = if (count dayz_Magazines > 0) then {dayz_Magazines} else {magazines player};
+			PVDZE_plr_Save = [player,_dayzMags,false,false];
 			publicVariableServer "PVDZE_plr_Save";
 			dayz_unsaved = false;
 			dayz_lastSave = time;
+			dayz_Magazines = [];
 		};
 	};
 


### PR DESCRIPTION
dayz_Magazines isn't always set before syncing the character, and especially considering this is just on a loop makes it very unreliable. If you input an empty array to the server_playerSync then it will wipe your backpack and weapons aswell. Noticed this bug when players were complaining about it since I switched completely over to extDB. I've taken a look at the HiveExt.dll source and I'm pretty sure I found a check in there to see if the array is empty, which is still a hacky fix for this. I honestly wonder what the devs of DayZ were doing when they made this mod, the coding is just horrendous. I feel like making my own version of it from scratch sometimes. Rant over... sorry lol. Back on topic, using magazines player won't record the clip count in a magazine, but the only time that actually seems to be saved is when the gear dialog is closed because that's the only time you can record it using the gear commands.